### PR TITLE
Add async support

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -43,11 +43,19 @@ if ((get-module psake) -eq $null) {
 
 if ((get-module psake) -eq $null) {
     # Still not loaded, let's try the various NuGet caches
-    $locals = nuget locals all -list
+    $nuget = get-command nuget -ErrorAction SilentlyContinue
+    $dotnet = get-command dotnet -ErrorAction SilentlyContinue
+    $locals = $null
+    if ($nuget -ne $null) {
+        $locals = & $nuget locals all -list
+    } elseif ($dotnet -ne $null) {
+        $locals = & $dotnet nuget locals all --list
+    }
+
     foreach($local in $locals)
     {
-        $index = $local.IndexOf(":")
-        $folder = $local.Substring($index + 2)
+        $index = $local.LastIndexOf(":")
+        $folder = $local.Substring($index - 1)
         TryLoad-Psake $folder
     }
 }

--- a/src/Niche.CommandLine/CommandLineExecuteActionSyntax.cs
+++ b/src/Niche.CommandLine/CommandLineExecuteActionSyntax.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Niche.CommandLine
 {
@@ -41,6 +42,30 @@ namespace Niche.CommandLine
             try
             {
                 action(_options);
+            }
+            catch (Exception e)
+            {
+                foreach (var message in e.AsStrings())
+                {
+                    _errorsReference.Add(message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Do something async and useful with a properly configured option
+        /// </summary>
+        /// <param name="action">Action to invoke.</param>
+        public async Task ExecuteAsync(Func<T, Task> action)
+        {
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            try
+            {
+                await action(_options);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Async overloads of `Execute()` to make it easier to use from **async** `Main()`.

Also improves the bootstrap script to better handle the case where `nuget` is not on the path.